### PR TITLE
Simplify cron EventType name

### DIFF
--- a/et2.yaml
+++ b/et2.yaml
@@ -1,7 +1,7 @@
 apiVersion: eventing.knative.dev/v1alpha1
 kind: EventType
 metadata:
-  name: cronjob-et
+  name: cron
 spec:
   type: dev.knative.cronjob.event
   importer:

--- a/t2.yaml
+++ b/t2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: t-cron
 spec:
   importers:
-    - eventTypeName: cronjob-et
+    - eventTypeName: cron
       arguments:
         schedule: "* * * * *"
   subscriber:


### PR DESCRIPTION
EventType is now `cron` instead of `cronjob-et`